### PR TITLE
Add BGM selection and centered settings UI

### DIFF
--- a/LJH/LJH8/webTeam.html
+++ b/LJH/LJH8/webTeam.html
@@ -38,6 +38,13 @@
     </label><br>
     <label>배경음 On/Off:
       <input type="checkbox" id="bgmToggle" checked>
+    </label><br>
+    <label>게임 BGM 선택:
+      <select id="bgmSelect">
+        <option value="Occam.mp3">Occam</option>
+        <option value="Occam2.mp3">Occam2</option>
+        <option value="Occam3.mp3">Occam3</option>
+      </select>
     </label>
 
     <h3>효과음 설정</h3>

--- a/LJH/LJH8/webTeam.js
+++ b/LJH/LJH8/webTeam.js
@@ -479,11 +479,11 @@ $(document).on("click", ".credit-close", function () {
 });
 
 $(document).on("click", "#setting", function () {
-  $("#settings-overlay").show();
+  $("#settings-overlay").css("display", "flex");
 });
 
 $(document).on("click", "#closeSettingsBtn", function () {
-  $("#settings-overlay").hide();
+  $("#settings-overlay").css("display", "none");
 });
 
 $(document).on("click", ".to-main", function () {
@@ -1157,6 +1157,7 @@ function applySettings() {
   const bgmToggle = $("#bgmToggle").is(":checked");
   const sfxToggle = $("#sfxToggle").is(":checked");
   const sVolume = parseFloat($("#sfxVolume").val());
+  const selectedBgm = $("#bgmSelect").val();
   selectedPlayerImage = $("#playerSelect").val();
 
   bgmTitle.volume = volume;
@@ -1169,6 +1170,14 @@ function applySettings() {
     bgmGame.pause();
   }
 
+  if (bgmGame.src.indexOf(selectedBgm) === -1) {
+    bgmGame.src = `BGM/${selectedBgm}`;
+    bgmGame.load();
+    if (bgmToggle) {
+      bgmGame.play().catch(()=>{});
+    }
+  }
+
   sfxEnabled = sfxToggle;
   sfxVolume = sVolume;
 
@@ -1176,7 +1185,7 @@ function applySettings() {
     window.playerImg.src = selectedPlayerImage;
   }
 
-  $("#settings-overlay").hide();
+  $("#settings-overlay").css("display", "none");
 }
 
 window.applySettings = applySettings;


### PR DESCRIPTION
## Summary
- center the settings overlay in LJH8
- allow choosing Occam, Occam2 or Occam3 as the game BGM
- hide/show overlay without breaking flex layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684343f7fed88327a43912eba2036494