### PR TITLE
Add persistent version UI and static brick logic

### DIFF
--- a/LJH/LJH8/webTeam.css
+++ b/LJH/LJH8/webTeam.css
@@ -448,17 +448,32 @@ body {
 }
 
 #outside-info{
+    position:fixed;
+    bottom:10px;
+    left:50%;
+    transform:translateX(-50%);
     display:flex;
-    justify-content: space-between;
+    justify-content: center;
     align-items:center;
+    gap:10px;
     font-family:'DungGeunMo';
     color:white;
-    margin:5px 0;
 }
 
 #outside-info input{
     font-family:'DungGeunMo';
     width:120px;
+}
+
+#endingBtn.highlight{
+    animation: ending-glow 1s infinite;
+    border:1px solid yellow;
+    padding:2px 8px;
+}
+
+@keyframes ending-glow{
+    0%,100%{ box-shadow:0 0 5px yellow; }
+    50%{ box-shadow:0 0 15px yellow; }
 }
 
 .diffselect-bar {

--- a/LJH/LJH8/webTeam.html
+++ b/LJH/LJH8/webTeam.html
@@ -25,7 +25,12 @@
     <!-- 시나리오 및 게임이 들어갈 영역 -->
     <div class="content" id="gameContent" style="display: none;"></div>
   </div>
-</div>
+
+  <div id="outside-info">
+    <label>이름: <input id="playerNameInput" type="text"></label>
+    <span id="versionTxt"></span>
+    <button id="endingBtn" style="display:none;">Ending</button>
+  </div>
 
 
 


### PR DESCRIPTION
## Summary
- show player name and version info at bottom of page
- keep Ending button hidden until goal reached and highlight it
- make static brick layouts per stage and update brick bounce logic
- avoid scoring on static bricks and make debris bounce off them
- store stage clear flag and show `1등 신기록` once cleared

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68434e1446388327875573ad87400472