### PR TITLE
Fix game over logic and collision

### DIFF
--- a/LJH/LJH8/webTeam.js
+++ b/LJH/LJH8/webTeam.js
@@ -911,10 +911,10 @@ function collisionDetection() {
     const bh = b.renderHeight || brickHeight;
     if (
       b.status === 1 &&
-      ball.x > b.x &&
-      ball.x < b.x + bw &&
-      ball.y > b.y &&
-      ball.y < b.y + bh
+      ball.x + ball.radius > b.x &&
+      ball.x - ball.radius < b.x + bw &&
+      ball.y + ball.radius > b.y &&
+      ball.y - ball.radius < b.y + bh
     ) {
       if (b.type !== "static") {
         b.status = 0;
@@ -1047,9 +1047,16 @@ function collisionDetection() {
   function endGame(where) {
     isGameRunning = false;
     clearInterval(timer);
-  
-    // 게임 오버 시점에 점수 기반 엔딩 화면 출력
-    showSpecialEnding(score)
+    $("#endingBtn").removeClass("highlight").hide();
+    recordHighScore(difficulty, $("#playerNameInput").val() || "Anon", score);
+    if (endingShown) {
+      setUnlockedStage(difficulty + 1);
+      localStorage.setItem(`sc_cleared_stage_${difficulty}`, "1");
+      showEnding(score);
+    } else {
+      // 게임 오버 시점에 점수 기반 엔딩 화면 출력
+      showSpecialEnding(score);
+    }
   }
   
 


### PR DESCRIPTION
## Summary
- fix ball collision detection with bricks using radius
- ensure score is recorded on game over
- hide ending button on game over and show ending if already cleared

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843546b9e9883279f7bef7920b95f7e