### PR TITLE
Fix BGM overlap when applying settings

### DIFF
--- a/LJH/LJH8/webTeam.js
+++ b/LJH/LJH8/webTeam.js
@@ -1390,9 +1390,10 @@ function applySettings() {
   }
 
   if (bgmGame.src.indexOf(selectedBgm) === -1) {
+    const wasPlaying = !bgmGame.paused;
     bgmGame.src = `BGM/${selectedBgm}`;
     bgmGame.load();
-    if (bgmToggle) {
+    if (bgmToggle && wasPlaying) {
       bgmGame.play().catch(()=>{});
     }
   }


### PR DESCRIPTION
## Summary
- ensure game BGM resumes only if it was already playing before applying settings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843f0b0901883279260db2a5a807a08