### PR TITLE
Implement floating spaceman and life loss SFX

### DIFF
--- a/LJH/LJH9/webTeam.css
+++ b/LJH/LJH9/webTeam.css
@@ -276,6 +276,18 @@ body {
     z-index: 2;
 }
 
+#spaceman {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 100px;
+    height: auto;
+    transform: translate(-50%, -50%);
+    animation: float 3s ease-in-out infinite;
+    pointer-events: none;
+    z-index: 1;
+}
+
 .star {
     position: absolute;
     width: 20px;

--- a/LJH/LJH9/webTeam.html
+++ b/LJH/LJH9/webTeam.html
@@ -10,6 +10,7 @@
   <div class="wrapper">
     <div class="background">
       <div class="star-container"></div>
+      <img id="spaceman" src="spaceman.png" alt="spaceman" />
     </div>
 
     <!-- 메인 메뉴 -->

--- a/LJH/LJH9/webTeam.js
+++ b/LJH/LJH9/webTeam.js
@@ -745,6 +745,7 @@ function loseLifeAndResetBall() {
   lives--;
   updateUI();
  flashBorder("glow-red");
+  playSFX("SFX/start.mp3");
   if (lives <= 0) {
     endGame("하트 소진");
     return;


### PR DESCRIPTION
## Summary
- show a floating spaceman image on the title screen
- play `start.mp3` whenever the player loses a heart, honoring SFX settings

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843fa057b4483278d11a69c80f3f7ef