### PR TITLE
Add animated star blocks

### DIFF
--- a/LJH/LJH9/webTeam.js
+++ b/LJH/LJH9/webTeam.js
@@ -118,6 +118,16 @@ const scenarioImages = [
 const debrisImg = new Image();
 debrisImg.src = "debris1.png";
 
+// 정적 블럭 애니메이션을 위한 별 이미지 프레임 로드
+const staticStarFrames = [];
+for (let i = 1; i <= 8; i++) {
+  const img = new Image();
+  img.src = `star/star${i}.png`;
+  staticStarFrames.push(img);
+}
+let staticStarFrame = 0;
+let staticStarCounter = 0;
+
 
 const scenarioTexts = [
   "2100년, 지구는 더 이상 푸르지 않았다.",
@@ -745,8 +755,8 @@ if (isBad) {
         status: 1,
         type: "static",
         img: null,
-        renderWidth: 30,
-        renderHeight: 30,
+        renderWidth: 45,
+        renderHeight: 45,
         preserveAspect: true
       });
     });
@@ -938,12 +948,25 @@ function drawPaddles() {
 
 
   function drawBricks() {
+    // 정적 블럭 애니메이션 프레임 업데이트 속도 조절
+    staticStarCounter++;
+    if (staticStarCounter % 10 === 0) {
+      staticStarFrame = (staticStarFrame + 1) % staticStarFrames.length;
+    }
     bricks.forEach(b => {
       if (b.status === 1) {
         const bw = b.renderWidth || brickWidth;
         const bh = b.renderHeight || brickHeight;
 
-        if (b.img && b.img.complete) {
+        if (b.type === "static") {
+          const frameImg = staticStarFrames[staticStarFrame];
+          if (frameImg.complete) {
+            ctx.drawImage(frameImg, b.x, b.y, bw, bh);
+          } else {
+            ctx.fillStyle = "gray";
+            ctx.fillRect(b.x, b.y, bw, bh);
+          }
+        } else if (b.img && b.img.complete) {
           ctx.drawImage(b.img, b.x, b.y, bw, bh);
         } else {
           ctx.fillStyle = b.bad ? "red" : "gray";


### PR DESCRIPTION
## Summary
- load star images for static block animation
- update `drawBricks` to cycle through star frames
- enlarge static star blocks and slow down frame changes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68441a31b42483278fff46cad4ac0c44